### PR TITLE
Replace function with procedure declaration when no return specified

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -49,24 +49,24 @@ skinparam rectangle<<boundary>> {
 ' Layout
 ' ##################################
 
-!function HIDE_STEREOTYPE()
+!procedure HIDE_STEREOTYPE()
 hide stereotype
-!endfunction
+!endprocedure
 
-!function LAYOUT_AS_SKETCH()
+!procedure LAYOUT_AS_SKETCH()
 skinparam backgroundColor #EEEBDC
 skinparam handwritten true
 skinparam defaultFontName "Comic Sans MS"
 center footer <font color=red>Warning:</font> Created for discussion, needs to be validated
-!endfunction
+!endprocedure
 
-!function LAYOUT_TOP_DOWN()
+!procedure LAYOUT_TOP_DOWN()
 top to bottom direction
-!endfunction
+!endprocedure
 
-!function LAYOUT_LEFT_RIGHT() 
+!procedure LAYOUT_LEFT_RIGHT() 
 left to right direction
-!endfunction
+!endprocedure
 
 ' Boundaries
 ' ##################################
@@ -81,105 +81,105 @@ left to right direction
 ' Relationship
 ' ##################################
 
-!unquoted function Rel_($alias1, $alias2, $label, $direction="")
+!unquoted procedure Rel_($alias1, $alias2, $label, $direction="")
 $alias1 $direction $alias2 : **$label**
-!endfunction
-!unquoted function Rel_($alias1, $alias2, $label, $techn, $direction="")
+!endprocedure
+!unquoted procedure Rel_($alias1, $alias2, $label, $techn, $direction="")
 $alias1 $direction $alias2 : **$label**\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//
-!endfunction
+!endprocedure
 
-!unquoted function Rel($from, $to, $label)
+!unquoted procedure Rel($from, $to, $label)
 Rel_($from, $to, $label, "-->>")
-!endfunction
-!unquoted function Rel($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_Back($from, $to, $label)
+!unquoted procedure Rel_Back($from, $to, $label)
 Rel_($from, $to, $label, "<<--")
-!endfunction
-!unquoted function Rel_Back($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Back($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "<<--")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_Neighbor($from, $to, $label)
+!unquoted procedure Rel_Neighbor($from, $to, $label)
 Rel_($from, $to, $label, "->>")
-!endfunction
-!unquoted function Rel_Neighbor($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Neighbor($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_Back_Neighbor($from, $to, $label)
+!unquoted procedure Rel_Back_Neighbor($from, $to, $label)
 Rel_($from, $to, $label, "<<-")
-!endfunction
-!unquoted function Rel_Back_Neighbor($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Back_Neighbor($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "<<-")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_D($from, $to, $label)
+!unquoted procedure Rel_D($from, $to, $label)
 Rel_($from, $to, $label, "-DOWN->>")
-!endfunction
-!unquoted function Rel_D($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_D($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-DOWN->>")
-!endfunction
-!unquoted function Rel_Down($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Down($from, $to, $label)
 Rel_($from, $to, $label, "-DOWN->>")
-!endfunction
-!unquoted function Rel_Down($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Down($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-DOWN->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_U($from, $to, $label)
+!unquoted procedure Rel_U($from, $to, $label)
 Rel_($from, $to, $label, "-UP->>")
-!endfunction
-!unquoted function Rel_U($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_U($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-UP->>")
-!endfunction
-!unquoted function Rel_Up($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Up($from, $to, $label)
 Rel_($from, $to, $label, "-UP->>")
-!endfunction
-!unquoted function Rel_Up($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Up($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-UP->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_L($from, $to, $label)
+!unquoted procedure Rel_L($from, $to, $label)
 Rel_($from, $to, $label, "-LEFT->>")
-!endfunction
-!unquoted function Rel_L($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_L($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-LEFT->>")
-!endfunction
-!unquoted function Rel_Left($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Left($from, $to, $label)
 Rel_($from, $to, $label, "-LEFT->>")
-!endfunction
-!unquoted function Rel_Left($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Left($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-LEFT->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_R($from, $to, $label)
+!unquoted procedure Rel_R($from, $to, $label)
 Rel_($from, $to, $label, "-RIGHT->>")
-!endfunction
-!unquoted function Rel_R($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_R($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-RIGHT->>")
-!endfunction
-!unquoted function Rel_Right($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Right($from, $to, $label)
 Rel_($from, $to, $label, "-RIGHT->>")
-!endfunction
-!unquoted function Rel_Right($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Right($from, $to, $label, $techn)
 Rel_($from, $to, $label, $techn, "-RIGHT->>")
-!endfunction
+!endprocedure
 
 ' Layout Helpers
 ' ##################################
 
-!unquoted function Lay_D($from, $to)
+!unquoted procedure Lay_D($from, $to)
 $from -[hidden]D- $to
-!endfunction
-!unquoted function Lay_U($from, $to)
+!endprocedure
+!unquoted procedure Lay_U($from, $to)
 $from -[hidden]U- $to
-!endfunction
-!unquoted function Lay_R($from, $to)
+!endprocedure
+!unquoted procedure Lay_R($from, $to)
 $from -[hidden]R- $to
-!endfunction
-!unquoted function Lay_L($from, $to)
+!endprocedure
+!unquoted procedure Lay_L($from, $to)
 $from -[hidden]L- $to
-!endfunction
+!endprocedure

--- a/C4_Component.puml
+++ b/C4_Component.puml
@@ -32,7 +32,7 @@ skinparam database<<component>> {
 ' Layout
 ' ##################################
 
-!function LAYOUT_WITH_LEGEND()
+!procedure LAYOUT_WITH_LEGEND()
 hide stereotype
 legend right
 |<color:$LEGEND_TITLE_COLOR>**Legend**</color> |
@@ -43,21 +43,21 @@ legend right
 |<$EXTERNAL_PERSON_BG_COLOR> external person |
 |<$EXTERNAL_SYSTEM_BG_COLOR> external system |
 endlegend
-!endfunction
+!endprocedure
 
 ' Elements
 ' ##################################
 
-!unquoted function Component($alias, $label, $techn)
+!unquoted procedure Component($alias, $label, $techn)
 rectangle "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//" <<component>> as $alias
-!endfunction
-!unquoted function Component($alias, $label, $techn, $descr)
+!endprocedure
+!unquoted procedure Component($alias, $label, $techn, $descr)
 rectangle "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//\n\n $descr" <<component>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function ComponentDb($alias, $label, $techn)
+!unquoted procedure ComponentDb($alias, $label, $techn)
 database "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//" <<component>> as $alias
-!endfunction
-!unquoted function ComponentDb($alias, $label, $techn, $descr)
+!endprocedure
+!unquoted procedure ComponentDb($alias, $label, $techn, $descr)
 database "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//\n\n $descr" <<component>> as $alias
-!endfunction
+!endprocedure

--- a/C4_Container.puml
+++ b/C4_Container.puml
@@ -32,7 +32,7 @@ skinparam database<<container>> {
 ' Layout
 ' ##################################
 
-!function LAYOUT_WITH_LEGEND()
+!procedure LAYOUT_WITH_LEGEND()
 hide stereotype
 legend right
 |<color:$LEGEND_TITLE_COLOR>**Legend**</color> |
@@ -42,24 +42,24 @@ legend right
 |<$EXTERNAL_PERSON_BG_COLOR> external person |
 |<$EXTERNAL_SYSTEM_BG_COLOR> external system |
 endlegend
-!endfunction
+!endprocedure
 
 ' Elements
 ' ##################################
 
-!unquoted function Container($alias, $label, $techn)
+!unquoted procedure Container($alias, $label, $techn)
 rectangle "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//" <<container>> as $alias
-!endfunction
-!unquoted function Container($alias, $label, $techn, $descr)
+!endprocedure
+!unquoted procedure Container($alias, $label, $techn, $descr)
 rectangle "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//\n\n $descr" <<container>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function ContainerDb($alias, $label, $techn)
+!unquoted procedure ContainerDb($alias, $label, $techn)
 database "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//" <<container>> as $alias
-!endfunction
-!unquoted function ContainerDb($alias, $label, $techn, $descr)
+!endprocedure
+!unquoted procedure ContainerDb($alias, $label, $techn, $descr)
 database "==$label\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//\n\n $descr" <<container>> as $alias
-!endfunction
+!endprocedure
 
 ' Boundaries
 ' ##################################

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -63,7 +63,7 @@ BorderColor #8A8A8A
 ' Layout
 ' ##################################
 
-!function LAYOUT_WITH_LEGEND()
+!procedure LAYOUT_WITH_LEGEND()
 hide stereotype
 legend right
 |<color:$LEGEND_TITLE_COLOR>**Legend**</color> |
@@ -72,52 +72,52 @@ legend right
 |<$EXTERNAL_PERSON_BG_COLOR> external person |
 |<$EXTERNAL_SYSTEM_BG_COLOR> external system |
 endlegend
-!endfunction
+!endprocedure
 
 ' Elements
 ' ##################################
 
-!unquoted function Person($alias, $label)
+!unquoted procedure Person($alias, $label)
 rectangle "==$label" <<person>> as $alias
-!endfunction
-!unquoted function Person($alias, $label, $descr)
+!endprocedure
+!unquoted procedure Person($alias, $label, $descr)
 rectangle "==$label\n\n $descr" <<person>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function Person_Ext($alias, $label)
+!unquoted procedure Person_Ext($alias, $label)
 rectangle "==$label" <<external_person>> as $alias
-!endfunction
-!unquoted function Person_Ext($alias, $label, $descr)
+!endprocedure
+!unquoted procedure Person_Ext($alias, $label, $descr)
 rectangle "==$label\n\n $descr" <<external_person>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function System($alias, $label)
+!unquoted procedure System($alias, $label)
 rectangle "==$label" <<system>> as $alias
-!endfunction
-!unquoted function System($alias, $label, $descr)
+!endprocedure
+!unquoted procedure System($alias, $label, $descr)
 rectangle "==$label\n\n $descr" <<system>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function System_Ext($alias, $label)
+!unquoted procedure System_Ext($alias, $label)
 rectangle "==$label" <<external_system>> as $alias
-!endfunction
-!unquoted function System_Ext($alias, $label, $descr)
+!endprocedure
+!unquoted procedure System_Ext($alias, $label, $descr)
 rectangle "==$label\n\n $descr" <<external_system>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function SystemDb($alias, $label)
+!unquoted procedure SystemDb($alias, $label)
 database "==$label" <<system>> as $alias
-!endfunction
-!unquoted function SystemDb($alias, $label, $descr)
+!endprocedure
+!unquoted procedure SystemDb($alias, $label, $descr)
 database "==$label\n\n $descr" <<system>> as $alias
-!endfunction
+!endprocedure
 
-!unquoted function SystemDb_Ext($alias, $label)
+!unquoted procedure SystemDb_Ext($alias, $label)
 database "==$label" <<external_system>> as $alias
-!endfunction
-!unquoted function SystemDb_ext($alias, $label, $descr)
+!endprocedure
+!unquoted procedure SystemDb_ext($alias, $label, $descr)
 database "==$label\n\n $descr" <<external_system>> as $alias
-!endfunction
+!endprocedure
 
 ' Boundaries
 ' ##################################

--- a/C4_Dynamic.puml
+++ b/C4_Dynamic.puml
@@ -18,13 +18,13 @@
 
 !$index=1
 
-!function increment($step=1)
+!procedure increment($step=1)
 !$index = $index + $step
-!endfunction
+!endprocedure
 
-!function setIndex($new_index)
+!procedure setIndex($new_index)
 !$index=$new_index
-!endfunction
+!endprocedure
 
 ' Relationship override
 ' ##################################
@@ -32,187 +32,187 @@
 ' Relationship
 ' ##################################
 
-!unquoted function Rel_($e_index, $alias1, $alias2, $label, $direction="")
+!unquoted procedure Rel_($e_index, $alias1, $alias2, $label, $direction="")
 $alias1 $direction $alias2 : **$e_index: $label**
-!endfunction
-!unquoted function Rel_($e_index, $alias1, $alias2, $label, $techn, $direction="")
+!endprocedure
+!unquoted procedure Rel_($e_index, $alias1, $alias2, $label, $techn, $direction="")
 $alias1 $direction $alias2 : **$e_index: $label**\n//<size:$TECHN_FONT_SIZE>[$techn]</size>//
-!endfunction
+!endprocedure
 
-!unquoted function Rel($from, $to, $label)
+!unquoted procedure Rel($from, $to, $label)
 Rel_($index, $from, $to, $label, "-->>")
 increment()
-!endfunction
-!unquoted function Rel($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-->>")
 increment()
-!endfunction
-!unquoted function RelIndex($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-->>")
-!endfunction
-!unquoted function RelIndex($e_index, $from, $to, $label, $tech)
+!endprocedure
+!unquoted procedure RelIndex($e_index, $from, $to, $label, $tech)
 Rel_($e_index, $from, $to, $label, $tech, "-->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_Back($from, $to, $label)
+!unquoted procedure Rel_Back($from, $to, $label)
 Rel_($index, $from, $to, $label, "<<--")
 increment()
-!endfunction
-!unquoted function Rel_Back($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Back($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "<<--")
 increment()
-!endfunction
-!unquoted function RelIndex_Back($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Back($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "<<--")
-!endfunction
-!unquoted function RelIndex_Back($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Back($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "<<--")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_Neighbor($from, $to, $label)
+!unquoted procedure Rel_Neighbor($from, $to, $label)
 Rel_($index, $from, $to, $label, "->>")
 increment()
-!endfunction
-!unquoted function Rel_Neighbor($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Neighbor($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "->>")
 increment()
-!endfunction
-!unquoted function RelIndex_Neighbor($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Neighbor($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "->>")
-!endfunction
-!unquoted function RelIndex_Neighbor($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Neighbor($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_Back_Neighbor($from, $to, $label)
+!unquoted procedure Rel_Back_Neighbor($from, $to, $label)
 Rel_($index, $from, $to, $label, "<<-")
 increment()
-!endfunction
-!unquoted function Rel_Back_Neighbor($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Back_Neighbor($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "<<-")
 increment()
-!endfunction
-!unquoted function RelIndex_Back_Neighbor($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Back_Neighbor($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "<<-")
-!endfunction
-!unquoted function RelIndex_Back_Neighbor($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Back_Neighbor($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "<<-")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_D($from, $to, $label)
+!unquoted procedure Rel_D($from, $to, $label)
 Rel_($index, $from, $to, $label, "-DOWN->>")
 increment()
-!endfunction
-!unquoted function Rel_D($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_D($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-DOWN->>")
 increment()
-!endfunction
-!unquoted function Rel_Down($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Down($from, $to, $label)
 Rel_($index, $from, $to, $label, "-DOWN->>")
 increment()
-!endfunction
-!unquoted function Rel_Down($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Down($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-DOWN->>")
 increment()
-!endfunction
-!unquoted function RelIndex_D($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_D($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-DOWN->>")
-!endfunction
-!unquoted function RelIndex_D($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_D($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-DOWN->>")
-!endfunction
-!unquoted function RelIndex_Down($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Down($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-DOWN->>")
-!endfunction
-!unquoted function RelIndex_Down($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Down($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-DOWN->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_U($from, $to, $label)
+!unquoted procedure Rel_U($from, $to, $label)
 Rel_($index, $from, $to, $label, "-UP->>")
 increment()
-!endfunction
-!unquoted function Rel_U($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_U($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-UP->>")
 increment()
-!endfunction
-!unquoted function Rel_Up($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Up($from, $to, $label)
 Rel_($index, $from, $to, $label, "-UP->>")
 increment()
-!endfunction
-!unquoted function Rel_Up($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Up($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-UP->>")
 increment()
-!endfunction
-!unquoted function RelIndex_U($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_U($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-UP->>")
-!endfunction
-!unquoted function RelIndex_U($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_U($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-UP->>")
-!endfunction
-!unquoted function RelIndex_Up($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Up($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-UP->>")
-!endfunction
-!unquoted function RelIndex_Up($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Up($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-UP->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_L($from, $to, $label)
+!unquoted procedure Rel_L($from, $to, $label)
 Rel_($index, $from, $to, $label, "-LEFT->>")
 increment()
-!endfunction
-!unquoted function Rel_L($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_L($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-LEFT->>")
 increment()
-!endfunction
-!unquoted function Rel_Left($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Left($from, $to, $label)
 Rel_($index, $from, $to, $label, "-LEFT->>")
 increment()
-!endfunction
-!unquoted function Rel_Left($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Left($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-LEFT->>")
 increment()
-!endfunction
-!unquoted function RelIndex_L($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_L($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-LEFT->>")
-!endfunction
-!unquoted function RelIndex_L($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_L($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-LEFT->>")
-!endfunction
-!unquoted function RelIndex_Left($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Left($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-LEFT->>")
-!endfunction
-!unquoted function RelIndex_Left($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Left($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-LEFT->>")
-!endfunction
+!endprocedure
 
-!unquoted function Rel_R($from, $to, $label)
+!unquoted procedure Rel_R($from, $to, $label)
 Rel_($index, $from, $to, $label, "-RIGHT->>")
 increment()
-!endfunction
-!unquoted function Rel_R($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_R($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-RIGHT->>")
 increment()
-!endfunction
-!unquoted function Rel_Right($from, $to, $label)
+!endprocedure
+!unquoted procedure Rel_Right($from, $to, $label)
 Rel_($index, $from, $to, $label, "-RIGHT->>")
 increment()
-!endfunction
-!unquoted function Rel_Right($from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure Rel_Right($from, $to, $label, $techn)
 Rel_($index, $from, $to, $label, $techn, "-RIGHT->>")
 increment()
-!endfunction
-!unquoted function RelIndex_R($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_R($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-RIGHT->>")
-!endfunction
-!unquoted function RelIndex_R($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_R($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-RIGHT->>")
-!endfunction
-!unquoted function RelIndex_Right($e_index, $from, $to, $label)
+!endprocedure
+!unquoted procedure RelIndex_Right($e_index, $from, $to, $label)
 Rel_($e_index, $from, $to, $label, "-RIGHT->>")
-!endfunction
-!unquoted function RelIndex_Right($e_index, $from, $to, $label, $techn)
+!endprocedure
+!unquoted procedure RelIndex_Right($e_index, $from, $to, $label, $techn)
 Rel_($e_index, $from, $to, $label, $techn, "-RIGHT->>")
-!endfunction
+!endprocedure
 
 


### PR DESCRIPTION
Hi, 

In the latest release of plantuml (V1.2020.7), if a function does not have a return directive we will get an error. 
See changes at https://github.com/plantuml/plantuml/commit/9077d971d71c5777f8d2d0a33da19fb7faef17ba, in the [`CodeIteratorReturnFunction.java`](https://github.com/plantuml/plantuml/blob/9077d971d71c5777f8d2d0a33da19fb7faef17ba/src/net/sourceforge/plantuml/tim/iterator/CodeIteratorReturnFunction.java#L78)

I've changed every `function` declaration to `procedure` where there is nothing returned.