### PR TITLE
Adding Queue types

### DIFF
--- a/C4.puml
+++ b/C4.puml
@@ -32,6 +32,11 @@ skinparam database {
     shadowing false
 }
 
+skinparam queue {
+    StereotypeFontSize 12
+    shadowing false
+}
+
 skinparam Arrow {
     Color #666666
     FontColor #666666

--- a/C4_Component.puml
+++ b/C4_Component.puml
@@ -29,6 +29,13 @@ skinparam database<<component>> {
     BorderColor #78A8D8
 }
 
+skinparam queue<<component>> {
+    StereotypeFontColor #000000
+    FontColor #000000
+    BackgroundColor $COMPONENT_BG_COLOR
+    BorderColor #78A8D8
+}
+
 ' Layout
 ' ##################################
 
@@ -69,4 +76,8 @@ rectangle "$getComponent($label, $techn, $descr, $sprite)" <<component>> as $ali
 
 !unquoted procedure ComponentDb($alias, $label, $techn, $descr="", $sprite="")
 database "$getComponent($label, $techn, $descr, $sprite)" <<component>> as $alias
+!endprocedure
+
+!unquoted procedure ComponentQueue($alias, $label, $techn, $descr="", $sprite="")
+queue "$getComponent($label, $techn, $descr, $sprite)" <<component>> as $alias
 !endprocedure

--- a/C4_Container.puml
+++ b/C4_Container.puml
@@ -29,6 +29,13 @@ skinparam database<<container>> {
     BorderColor #3C7FC0
 }
 
+skinparam queue<<container>> {
+    StereotypeFontColor $ELEMENT_FONT_COLOR
+    FontColor $ELEMENT_FONT_COLOR
+    BackgroundColor $CONTAINER_BG_COLOR
+    BorderColor #3C7FC0
+}
+
 ' Layout
 ' ##################################
 
@@ -68,6 +75,10 @@ rectangle "$getContainer($label, $techn, $descr, $sprite)" <<container>> as $ali
 
 !unquoted procedure ContainerDb($alias, $label, $techn, $descr="", $sprite="")
 database "$getContainer($label, $techn, $descr, $sprite)" <<container>> as $alias
+!endprocedure
+
+!unquoted procedure ContainerQueue($alias, $label, $techn, $descr="", $sprite="")
+queue "$getContainer($label, $techn, $descr, $sprite)" <<container>> as $alias
 !endprocedure
 
 ' Boundaries

--- a/C4_Context.puml
+++ b/C4_Context.puml
@@ -60,6 +60,20 @@ skinparam database<<external_system>> {
     BorderColor #8A8A8A
 }
 
+skinparam queue<<system>> {
+    StereotypeFontColor $ELEMENT_FONT_COLOR
+    FontColor $ELEMENT_FONT_COLOR
+    BackgroundColor $SYSTEM_BG_COLOR
+    BorderColor #3C7FC0
+}
+
+skinparam queue<<external_system>> {
+    StereotypeFontColor $ELEMENT_FONT_COLOR
+    FontColor $ELEMENT_FONT_COLOR
+    BackgroundColor $EXTERNAL_SYSTEM_BG_COLOR
+    BorderColor #8A8A8A
+}
+
 sprite $person [48x48/16] {
 000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000
@@ -180,6 +194,14 @@ database "$getSystem($label, $descr, $sprite)" <<system>> as $alias
 
 !unquoted procedure SystemDb_ext($alias, $label, $descr="", $sprite="")
 database "$getSystem($label, $descr, $sprite)" <<external_system>> as $alias
+!endprocedure
+
+!unquoted procedure SystemQueue($alias, $label, $descr="", $sprite="")
+queue "$getSystem($label, $descr, $sprite)" <<system>> as $alias
+!endprocedure
+
+!unquoted procedure SystemQueue_ext($alias, $label, $descr="", $sprite="")
+queue "$getSystem($label, $descr, $sprite)" <<external_system>> as $alias
 !endprocedure
 
 ' Boundaries


### PR DESCRIPTION
We use a lot of event queues and I think this might be a helpful addition to so that Kafka, Kinesis, etc can be modeled without using `*Db`.